### PR TITLE
Factor out `net/url.Parse`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 sudo: required
 
 go:
-  - 1.6
-  - 1.7
+  - 1.12
+  - 1.13
 
 go_import_path: github.com/db-journey/migrate
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ postgres:
   image: postgres
 mysql:
   image: mysql
+  command: --default-authentication-plugin=mysql_native_password
   environment:
     MYSQL_DATABASE: migratetest
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -4,7 +4,7 @@ package driver
 import (
 	"fmt"
 	"reflect"
-	"regexp" // alias to allow `url string` func signature in New
+	"regexp"
 
 	"github.com/db-journey/migrate/file"
 )

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,0 +1,72 @@
+// Package driver holds the driver interface.
+package driver
+
+import "testing"
+
+func Test_getScheme(t *testing.T) {
+	type args struct {
+		url string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "MySQL",
+			args: args{
+				url: "mysql://root:@(localhost:3306)/db",
+			},
+			want: "mysql",
+		},
+		{
+			name: "PostgreSQL",
+			args: args{
+				url: "postgres://root@localhost:3306/db",
+			},
+			want: "postgres",
+		},
+		{
+			name: "Cassandra",
+			args: args{
+				url: "cassandra://localhost:3306/keyspace",
+			},
+			want: "cassandra",
+		},
+		{
+			name: "SQLite",
+			args: args{
+				url: "sqlite3://database.sqlite",
+			},
+			want: "sqlite3",
+		},
+		{
+			name: "invalid",
+			args: args{
+				url: "root@localhost",
+			},
+			want: "",
+		},
+		{
+			name: "malformed mysql",
+			args: args{
+				url: "mysql:/root:@localhost",
+			},
+			want: "",
+		},
+		{
+			name: "malformed mysql",
+			args: args{
+				url: ":mysql://root:@localhost",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getScheme(tt.args.url); got != tt.want {
+				t.Errorf("getScheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"reflect"
 	"testing"
+
 	// Ensure imports for each driver we wish to test
 
 	_ "github.com/db-journey/cassandra-driver"


### PR DESCRIPTION
Remove the dependency on `url.Parse`, since it is not safe to assume that a DB connection string is always parseable as a URL.

Instead, extract the schema manually, as this was the only purpose of calling `url.Parse` in the first place.